### PR TITLE
Add additional settings for combat & aliance raids

### DIFF
--- a/RezoPlugin/Config.cs
+++ b/RezoPlugin/Config.cs
@@ -9,7 +9,11 @@ namespace RezoPlugin
         internal bool _enabled = true;
         internal bool _onlyMin = false;
         internal float _scale = 0.25f;
+        internal float _scaleInCombat = 0.25f;
+        internal float _scaleInAllianceCombat = 0.25f;
         internal bool _disableFsrSharpen = false;
+        internal bool _scaleInCombatEnabled = false;
+        internal bool _scaleInAllianceCombatEnabled = false;
 
         /// <inheritdoc/>
         int IPluginConfiguration.Version { get; set; } = 0;
@@ -33,6 +37,34 @@ namespace RezoPlugin
         {
             get => this._scale;
             set => this._scale = value;
+        }
+
+        /// <summary>3D Resolution Scaling to force while in combat.</summary>
+        public float ScaleInCombat
+        {
+            get => this._scaleInCombat;
+            set => this._scaleInCombat = value;
+        }
+
+        /// <summary>3D Resolution Scaling to force while in combat while in an alliance.</summary>
+        public float ScaleInAllianceCombat
+        {
+            get => this._scaleInAllianceCombat;
+            set => this._scaleInAllianceCombat = value;
+        }
+
+        // <summary>Weather to use caleInAllianceCombat</summary>
+        public bool ScaleInCombatEnabled
+        {
+            get => this._scaleInCombatEnabled;
+            set => this._scaleInCombatEnabled = value;
+        }
+
+        // <summary>Weather to use ScaleInAllianceCombat</summary>
+        public bool ScaleInAllianceCombatEnabled
+        {
+            get => this._scaleInAllianceCombatEnabled;
+            set => this._scaleInAllianceCombatEnabled = value;
         }
 
         public bool DisableFSRSharpen

--- a/RezoPlugin/ConfigUi.cs
+++ b/RezoPlugin/ConfigUi.cs
@@ -41,6 +41,20 @@ namespace RezoPlugin
 
             ImGui.SliderFloat("3D Resolution Scale", ref this.Config._scale, 0.1f, this.Config.OnlyMinimum ? 0.5f : 1.0f);
 
+            ImGui.Checkbox("Use Alternate Setting for Combat", ref this.Config._scaleInCombatEnabled);
+            if (this.Config._scaleInCombatEnabled)
+            {
+                ImGui.SameLine();
+                ImGui.SliderFloat("3D Resolution Scale During Combat", ref this.Config._scaleInCombat, 0.1f, this.Config.OnlyMinimum ? 0.5f : 1.0f);
+            }
+
+            ImGui.Checkbox("Use Alternate Setting for Combat (Alliance)", ref this.Config._scaleInAllianceCombatEnabled);
+            if (this.Config._scaleInAllianceCombatEnabled)
+            {
+                ImGui.SameLine();
+                ImGui.SliderFloat("3D Resolution Scale During Combat (Alliance)", ref this.Config._scaleInAllianceCombat, 0.1f, this.Config.OnlyMinimum ? 0.5f : 1.0f);
+            }
+
             ImGui.Checkbox("Disable Sharpen filter", ref this.Config._disableFsrSharpen);
             if (ImGui.IsItemHovered()) ImGui.SetTooltip("Disables the sharpen filter from FSR");
             ImGui.EndDisabled();

--- a/RezoPlugin/Service.cs
+++ b/RezoPlugin/Service.cs
@@ -1,0 +1,19 @@
+﻿using Dalamud.IoC;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+
+namespace RezoPlugin
+{
+    internal class Service
+    {
+        internal IDalamudPluginInterface PluginInterface { get; private set; } = null!;
+        [PluginService] public static ICondition Condition { get; private set; } = null!;
+        [PluginService] public static IClientState ClientState { get; private set; } = null!;
+
+        public void InitializeService(IDalamudPluginInterface pluginInterface)
+        {
+            this.PluginInterface = pluginInterface;
+            this.PluginInterface.Create<Service>();
+        }
+    }
+}


### PR DESCRIPTION
Super neat plugin!

I wanted an option to change the resolution to a different value when in combat. I added an additional option for alliance raids since those can be rough for lower end users.
